### PR TITLE
Added link to Honeycomb observability SaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Tools for rocessing the system data.
  * [dynatrace APM](https://www.dynatrace.com/platform/application-performance-monitoring/) - Best-in-class APM from the category leader. Ensure application performance, innovate faster, collaborate efficiently, and deliver more value with dramatically less effort
  * [Elastic APM](https://www.elastic.co/es/apm) - Application performance monitoring system built on the Elastic Stack
  * [DataDog](https://www.datadoghq.com/) - Unified Monitoring For Metrics, Traces, & Logs
+ * [Honeycomb](https://www.honeycomb.io/) - Give all software engineering teams the observability they need to eliminate toil and delight their users.
  * [NewRelic](https://newrelic.com/) - Complete view of your applications and operating environment
  * [AppDynamics](https://www.appdynamics.com/) - Business and application performance monitoring
  * [SPM](https://sematext.com/spm/) - solutions for performance monitoring.


### PR DESCRIPTION
I noticed Honeycomb.io was missing from the list.