### PR TITLE
Adding nthlayer to alerts list

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Tools for rocessing the system data.
 - [Flapjack](http://flapjack.io/) - Monitoring notification routing & event processing system.
 - [Seyren](https://github.com/scobal/seyren) - An alerting dashboard for Graphite.
 - [Cabot](https://cabotapp.com/) - Get alerted when services go down or metrics go crazy.
+- [NthLayer](https://github.com/rsionnach/nthlayer) - Reliability requirements as code. Generates Grafana dashboards, Prometheus alerts, SLOs, and PagerDuty configs from service.yaml. Includes deployment gates that block deploys when error budget is exhausted.
 
 ### Triggers
 


### PR DESCRIPTION
Adds [NthLayer](https://github.com/rsionnach/nthlayer) to the Alerts section.

     NthLayer is a reliability-as-code platform that generates observability artifacts from a single
     `service.yaml` spec:

     - **Grafana dashboards** - Service health visualization
     - **Prometheus alerts** - Multiburn SLO alerts (leverages Sloth)
     - **Recording rules** - Pre-aggregated metrics
     - **PagerDuty configs** - Teams, escalation policies, services
     - **Deployment gates** - Block deploys when error budget exhausted (`nthlayer check-deploy`)

     ### Key Features
     - CLI-based generation for GitOps/CI-CD workflows
     - Contract verification (`nthlayer verify`) ensures metrics exist before deploy
     - Technology templates for PostgreSQL, Redis, Kafka, etc.
     - Generates Sloth-compatible SLO specs

     ### Why it fits the Alerts section
     NthLayer complements Sloth (already in this list) by providing a broader reliability workflow while using
     Sloth for SLO rule generation. It adds deployment gates that prevent deploys when SLOs are at risk.
