### PR TITLE
Add API Status Check to Uptime section

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 
 ### Uptime
 
+- [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring for 120+ developer APIs including AWS, Stripe, GitHub, OpenAI, and more. Track third-party API availability with alerts and status pages.
 - [BlueWave Uptime](https://github.com/bluewave-labs/bluewave-uptime) - Open-source, self-hosted monitoring tool built with React.js, Node.js, and MongoDB, designed to track server uptime, response times, and incidents in real-time with beautiful visualizations.
 - [Monitive](http://monitive.com) - Free for 1 service, checked every 10 minutes with unlimited email & twitter alerts.
 - [UptimeRobot](https://uptimerobot.com) - Free for 50 monitors, checked every 5 minutes.


### PR DESCRIPTION
API Status Check is a free real-time status monitoring service for 120+ developer APIs including AWS, Stripe, GitHub, OpenAI, and more.

Relevant for developers and teams who need to monitor third-party API dependencies and receive alerts when services experience outages.