### PR TITLE
Add SSL Certificate Monitor and DNS Propagation Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ There are many more commands and methodologies you can apply to drill deeper.
 ### Metrics
 
 - [MyScale Telemetry](https://github.com/myscale/myscale-telemetry) - Tool designed to enhance the observability of LLM applications by capturing trace data from LangChain-based applications and storing it in MyScaleDB or ClickHouse.
+- [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) - Open-source SSL/TLS certificate expiry monitoring tool with email alerts for observability of certificate health.
+- [DNS Propagation Checker](https://github.com/brancogao/dns-propagation-checker) - Open-source DNS propagation monitoring tool with global DNS server coverage for DNS observability.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - Open-source observability for your LLM application, based on OpenTelemetry.
 - [OpenLLMetry for Javascript](https://github.com/traceloop/openllmetry-js) - Sister project to OpenLLMetry, but in Typescript. Open-source observability for your LLM application, based on OpenTelemetry.
 - [OpenLLMetry for Go](https://github.com/traceloop/go-openllmetry) - Sister project to OpenLLMetry, but in Go. Open-source observability for your LLM application, based on OpenTelemetry.


### PR DESCRIPTION
## Added Tools

### SSL Certificate Monitor
- **URL**: https://github.com/brancogao/ssl-certificate-monitor
- **Demo**: https://ssl-certificate-monitor.autocompany.workers.dev
- **Description**: Open-source SSL/TLS certificate expiry monitoring tool
- **Features**:
  - Real-time SSL certificate expiry checking
  - Email alerts before certificate expiration
  - Support for multiple domains
  - Clean web interface
  - RESTful API

### DNS Propagation Checker
- **URL**: https://github.com/brancogao/dns-propagation-checker
- **Demo**: https://dns-propagation-checker.autocompany.workers.dev
- **Description**: Open-source DNS propagation monitoring tool
- **Features**:
  - Global DNS server coverage (10+ DNS servers)
  - Support for A/AAAA/CNAME/MX/NS/TXT records
  - Propagation percentage visualization
  - RESTful API with caching

Both tools contribute to observability by providing visibility into:
- SSL/TLS certificate health and expiration status
- DNS propagation status across global DNS servers

## Checklist
- [x] The tool is open-source
- [x] The tool is relevant to observability/monitoring
- [x] The description follows the format of existing entries