### PR TITLE
Add duplicacy-exporter to Collect > Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ There are many more commands and methodologies you can apply to drill deeper.
 - [MyPerf4J](https://github.com/LinShunKang/MyPerf4J) - High performance Java APM. Powered by ASM. Try it. Test it. If you feel its better, use it.
 - [SkyAPM-dotnet](https://github.com/SkyAPM/SkyAPM-dotnet) - SkyAPM-dotnet provides the native support agent in C# and .NETStandard platform, with the helps from Apache SkyWalking committer team.
 - [pktvisor](https://github.com/ns1labs/pktvisor) - Observability agent for summarizing high volume, information dense data streams down to lightweight, immediately actionable observability data directly at the edge.
+- [duplicacy-exporter](https://github.com/GeiserX/duplicacy-exporter) - Real-time Prometheus exporter for Duplicacy backups with live speed, progress, and completion metrics.
 
 ### Tracing
 


### PR DESCRIPTION
## Summary
Adds [duplicacy-exporter](https://github.com/GeiserX/duplicacy-exporter) to the Collect > Metrics section.

A real-time Prometheus exporter for Duplicacy backups that exposes metrics on backup speed, progress, and completion status. GPL-3.0 licensed, Docker-ready.