### PR TITLE
Add Ingero - eBPF-based GPU causal observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [swagger-stats](https://swaggerstats.io/) - API Telemetry and APM.
 - [Cloudprober](https://github.com/google/cloudprober) - An active monitoring software to detect failures before your customers do.
 - [Hubble](https://github.com/cilium/hubble) - Network, Service & Security Observability for Kubernetes.
+- [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA Runtime/Driver APIs and host kernel events to build causal chains explaining GPU latency in production.
 - [Datav](https://github.com/datav-io/datav) - A modern apm solution for enterprise, an open-source alternative to DataDog, New Relic, etc.
 - [SigNoz](https://github.com/SigNoz/signoz) - Monitor your applications and troubleshoot problems in your deployed applications, an open-source alternative to DataDog, New Relic, etc.
 - [SkyWalking](https://skywalking.apache.org/) - Application performance monitor tool for distributed systems, especially designed for microservices, cloud native and container-based (Docker, K8s, Mesos) architectures.


### PR DESCRIPTION
Adds [Ingero](https://github.com/ingero-io/ingero) to the APM section.

Ingero is an open-source, eBPF-based GPU causal observability agent. It traces CUDA Runtime/Driver APIs via uprobes and host kernel events (scheduler, memory, I/O, network) via tracepoints to build causal chains explaining GPU latency in production. Designed for zero-config, <2% overhead, always-on use on Linux 5.15+ with NVIDIA GPUs.

Key features:
- **eBPF uprobes** on `libcudart.so` and `libcuda.so` (no CUPTI, no SDK injection)
- **Host kernel tracepoints** (sched_switch, block I/O, TCP retransmits, network socket I/O)
- **4-layer causal chain engine** linking system context → host events → CUDA calls → root cause
- **MCP server** for AI-assisted GPU debugging
- SQLite storage, OTLP/Prometheus export, Kubernetes-native (Helm chart + DaemonSet)

Written in Go + eBPF C, Apache 2.0 / GPL-2.0 dual-licensed (standard eBPF project pattern).