### PR TITLE
Add AgentWatch to APM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Tools for rocessing the system data.
 
 ## 10. Application Performance Monitoring Solutions (APM)
 
+- [AgentWatch](https://github.com/nicofains1/agentwatch) - Multi-agent fleet observability with cascade failure detection, heartbeat monitoring, and forensic replay.
 - [OpenLIT](https://github.com/openlit/openlit) - OTel-native Observability and Evals for LLMs & GPUs.
 - [Langtrace](https://github.com/Scale3-Labs/langtrace) - Open Source & Open Telemetry(OTEL) Observability for LLM applications.
 - [servicenow - Cloud Observability](https://www.servicenow.com/products/observability.html) - Gain AI-powered insights to detect and quickly respond to changes in cloud-native and monolithic applications. 


### PR DESCRIPTION
Adds [AgentWatch](https://github.com/nicofains1/agentwatch) to the APM section.

AgentWatch provides multi-agent fleet observability with cascade failure detection, heartbeat monitoring, and forensic replay. It correlates failures across agent chains that per-agent tracing tools miss.

- npm: @nicofains1/agentwatch
- 16 tests passing
- CLI: npx agentwatch dashboard|cascade|failures|alerts|replay

Ref: #30