### PR TITLE
Add burn0 to cost observability tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 
 - [Manifest](https://github.com/mnfst/manifest) - Open-source real-time cost observability for AI agents. Tracks tokens, costs, messages, and model usage. Self-hostable, privacy-focused, and OTLP-native.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers. Background daemon with SQLite storage, Material Design 3 web dashboard, and zero telemetry.
+- [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.
 
 ## 11. Application Performance Monitoring Solutions (APM)
 


### PR DESCRIPTION
Added burn0 to the Cost & Usage Tracking section under LLM & AI Observability.

burn0 is an open-source Node.js package that tracks per-request API costs for 50+ services with a single import. It uses HTTP interception to auto-detect services and extract cost metadata with sub-millisecond overhead.