### PR TITLE
Add Prefactor – AI agent runtime control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Helicone](https://github.com/Helicone/helicone) - Open source LLM observability platform and AI Gateway. One line of code to monitor, evaluate, and experiment across 100+ providers.
 - [OpenLIT](https://github.com/openlit/openlit) - OTel-native observability and evals for LLMs and GPUs.
 - [Langtrace](https://github.com/Scale3-Labs/langtrace) - Open source OpenTelemetry-based observability for LLM applications.
+* [Prefactor](https://prefactor.tech/) - Runtime control plane for AI agents; provides real-time visibility, governance, and policy enforcement across multi-agent workflows in regulated industries.
 - [Opik](https://github.com/comet-ml/opik) - Debug, evaluate, and monitor LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards.
 - [Laminar](https://github.com/lmnr-ai/lmnr) - Open-source observability and analytics platform purpose-built for AI agents. Built in Rust for performance.
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.


### PR DESCRIPTION
## Summary
Adds [Prefactor](https://prefactor.tech/) to the LLM / AI Agents observability section.

**What it does:** Prefactor is a runtime control plane for AI agents — it provides real-time observability, governance, and policy enforcement across multi-agent workflows. Purpose-built for regulated industries (healthcare, finance, insurance).

**Why it fits this list:** Prefactor sits squarely in the LLM observability + agent governance space alongside existing entries like OpenLLMetry and Langtrace, with a specific focus on runtime control and compliance.

**Links:** [Website](https://prefactor.tech/) · [Docs](https://docs.prefactor.ai)