### PR TITLE
Add ReleaseRun to monitoring and release tracking tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ In the article you can see how with a few tools and in a short time, you can get
 
 There are many more commands and methodologies you can apply to drill deeper.
 
+- [ReleaseRun](releaserun.com) — ReleaseRun — release monitoring and dependency EOL tracking — free tools for K8s API deprecation checking, Helm chart compatibility, and dependency health
 ## 3. Collect
 
  Get any data – metrics, events, logs, traces – from everywhere – systems, sensors, queues, databases and networks.


### PR DESCRIPTION
**ReleaseRun** (https://releaserun.com) is a free platform for software release monitoring and dependency health tracking.

It provides browser-based tools for:
- Kubernetes API deprecation checking before cluster upgrades
- Dependency EOL scanning (npm, pip, cargo, gem, composer, go.mod)
- CVE dashboard and release monitoring across 13+ technologies
- Helm chart compatibility checking

Used by DevOps and SRE teams to stay ahead of breaking changes in their stack.