### PR TITLE
Add GreptimeDB to Storage > Time Series Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [TimescaleDB](https://www.timescale.com/) - PostgreSQL for time‑series.
 - [QuestDB](https://questdb.io/) - The fastest open source time series database.
 - [Metric Tank](https://github.com/grafana/metrictank) - Provides high availability and efficient long-term storage, retrieval, and processing for large-scale environments.
+- [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) - Open-source, cloud-native observability database with unified SQL and PromQL support for metrics, logs, and traces.
 
 ### Time Series Cache
 


### PR DESCRIPTION
Add [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) - an open-source, cloud-native observability database built in Rust, with unified SQL and PromQL support for metrics, logs, and traces.