### PR TITLE
Add PFC-JSONL - JSONL log compressor with timestamp indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [Logbook](https://github.com/zalando/logbook) - Extensible Java library to enable complete request and response logging for different client- and server-side technologies.
 - [logdy](https://github.com/logdyhq/logdy-core) - Supercharge terminal logs with web browser UI and low-code. It's like jq, tail, less, grep and awk merged together and available in a clean UI. Self-hosted, single binary.
 - [Last9](https://last9.io/docs/logs/) - Unified Logs Explorer with search, filters, SQL query support, and OpenTelemetry-native ingestion.
+- [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing for efficient log storage. ~9% compression ratio with Fluent Bit integration and DuckDB queryable archives.
 
 ### Events
 


### PR DESCRIPTION
Adds [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl), a specialized JSONL log compressor with block-level timestamp indexing.

- ~9% compression ratio (vs gzip ~12%, zstd ~14%)
- DuckDB queryable: `INSTALL pfc FROM community; LOAD pfc;`
- Fluent Bit compatible (pfc-fluentbit forwarder)
- pfc-migrate for migrating existing gzip/bz2/zstd archives