### PR TITLE
Add CueAPI to LLM & AI Observability > Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Laminar](https://github.com/lmnr-ai/lmnr) - Open-source observability and analytics platform purpose-built for AI agents. Built in Rust for performance.
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.
+- [CueAPI](https://github.com/cueapi/cueapi-core) - Open-source observability for AI agent execution outcomes. Tracks verified vs. reported success rates, outcome timeouts, and verification-pending backlogs across scheduled agent work. Self-hosted, Apache-2.0.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
Adds CueAPI to section `10. LLM & AI Observability` → `Platforms`.

CueAPI is an open-source observability layer for AI agent execution outcomes. Operators monitor:

- verified vs. reported success rates (reported = agent said it succeeded; verified = evidence proves it did)
- outcome timeouts (agents that never reported)
- verification-pending backlog (outcomes that need human review)

across scheduled agent work. Self-hosted, Apache-2.0.

Repo: https://github.com/cueapi/cueapi-core

Placed at end of `Platforms` list per current ordering.