### PR TITLE
Add FutureAGI traceAI and FutureAGI futureagi-sdk link to awesome-observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ There are many more commands and methodologies you can apply to drill deeper.
 
 ### Tracing
 
+- [FutureAGI traceAI](https://github.com/future-agi/traceAI)
+- [FutureAGI futureagi-sdk](https://github.com/future-agi/futureagi-sdk)
+
 - [Sleuth](https://spring.io/projects/spring-cloud-sleuth) - Spring Cloud Sleuth implements a distributed tracing solution for Spring Cloud, borrowing heavily from Dapper, Zipkin and HTrace.
 <!--lint ignore double-link-->
 - [inspectIT Ocelot](https://github.com/inspectIT/inspectit-ocelot) - Java agent for collecting performance, tracing and business data.


### PR DESCRIPTION
Add FutureAGI traceAI and FutureAGI futureagi-sdk to the README in the appropriate section.