### PR TITLE
Add Uptrack to Observability as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 <!--lint ignore double-link-->
 - [Sematext Cloud](https://sematext.com/) - Infrastructure and log monitoring with service and log auto-discovery. Basic plan is free. Website uptime, API, and SSL certificate monitoring. Includes status pages and scriptable multi-page user transaction monitoring, etc.
 - [Dash0](https://www.dash0.com/) - Modern OpenTelemetry Native Observability, built on CNCF Open Standards such as PromQL, Perses and OLTP with full cost control. Supports monitoring metrics, logs and traces. With dashboarding and alerting capabilities.
+- [Uptrack](https://uptrack.app) - Uptime monitoring with 30-second checks on the free tier, consecutive-check alert confirmation (multi-region majority vote), hosted status pages, and a built-in MCP server for AI-agent-driven incident triage. HTTP, SSL, TCP, DNS, Ping, Heartbeat, and Cron monitors.
 
 ## 15. Examples and Sandboxes
 


### PR DESCRIPTION
Adds [Uptrack](https://uptrack.app) to section 14 (Observability as a Service).

Uptrack focuses on the uptime/SLA side of observability — HTTP, HTTPS (keyword), SSL, TCP, DNS, Ping, Heartbeat, and Cron monitors with consecutive-check alert confirmation across three regions (EU/US/India). That alert-confirmation pattern directly addresses the monitoring false-positive problem that motivates observability practices in the first place.

**Differentiators vs other entries**:
- 30-second check interval on the free tier
- Built-in MCP server (AI agents can list monitors, create new ones, and acknowledge incidents)
- Hosted public status pages + custom domains

Free forever plan: 50 monitors, no credit card.