### PR TITLE
Add France Nuage Managed Grafana to Observability as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [Sematext Cloud](https://sematext.com/) - Infrastructure and log monitoring with service and log auto-discovery. Basic plan is free. Website uptime, API, and SSL certificate monitoring. Includes status pages and scriptable multi-page user transaction monitoring, etc.
 - [Dash0](https://www.dash0.com/) - Modern OpenTelemetry Native Observability, built on CNCF Open Standards such as PromQL, Perses and OLTP with full cost control. Supports monitoring metrics, logs and traces. With dashboarding and alerting capabilities.
 - [Uptrack](https://uptrack.app) - Uptime monitoring with 30-second checks on the free tier, consecutive-check alert confirmation (multi-region majority vote), hosted status pages, and a built-in MCP server for AI-agent-driven incident triage. HTTP, SSL, TCP, DNS, Ping, Heartbeat, and Cron monitors.
+- [France Nuage Managed Grafana](https://france-nuage.fr) - Managed monitoring platform hosted in France with Grafana, Prometheus, Loki and Tempo. Data sovereignty compliant, backed by French infrastructure.
 
 ## 15. Examples and Sandboxes
 


### PR DESCRIPTION
Added [France Nuage Managed Grafana](https://france-nuage.fr) to the **Observability as a Service** section.

France Nuage provides a managed monitoring platform hosted in France with Grafana, Prometheus, Loki and Tempo, with full data sovereignty compliance backed by French infrastructure.