### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 ### Cost & Usage Tracking
 
 - [Manifest](https://github.com/mnfst/manifest) - Open-source real-time cost observability for AI agents. Tracks tokens, costs, messages, and model usage. Self-hostable, privacy-focused, and OTLP-native.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Open-source TUI observability for local AI coding agent sessions. Tracks tokens, cost, latency, tool failures, anomalies, health scores, diffs, and CI health gates across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and more.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers. Background daemon with SQLite storage, Material Design 3 web dashboard, and zero telemetry.
 - [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.
 - [Burnd](https://github.com/garvitsurana/burnd) - Local-first CLI that reads Claude Code JSONL session files and surfaces cost leaks via pattern detectors (retry storms, tool overuse, repeated reads, thrash, etc.). npx-installable, MIT, zero telemetry; findings export to a shareable report URL.


### PR DESCRIPTION
## Summary

Adds agenttrace to the LLM & AI Observability section under Cost & Usage Tracking.

agenttrace is a local-first TUI for AI coding agent session observability. It tracks tokens, estimated cost, latency, tool failures, anomalies, health scores, diffs, and CI health gates across tools such as Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and more.

## Validation

- `npx --yes awesome-lint`
