### PR TITLE
Add agenttrace to AI cost tracking tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers. Background daemon with SQLite storage, Material Design 3 web dashboard, and zero telemetry.
 - [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.
 - [Burnd](https://github.com/garvitsurana/burnd) - Local-first CLI that reads Claude Code JSONL session files and surfaces cost leaks via pattern detectors (retry storms, tool overuse, repeated reads, thrash, etc.). npx-installable, MIT, zero telemetry; findings export to a shareable report URL.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
Adds agenttrace to the LLM & AI Observability / Cost & Usage Tracking section.

agenttrace is a local TUI observability tool for AI coding agents, tracking cost, tokens, tool failures, anomalies, health, and CI gate signals across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.