### PR TITLE
Add BrowserTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - Open-source observability for LLM applications, based on OpenTelemetry.
 - [MyScale Telemetry](https://github.com/myscale/myscale-telemetry) - Tool designed to enhance the observability of LLM applications by capturing trace data from LangChain-based applications and storing it in MyScaleDB or ClickHouse.
+- [BrowserTrace](https://github.com/aaronlab/browsertrace) - Local-first trace viewer for AI browser-agent failures, capturing screenshots, URLs, actions, model I/O, status, errors, and public-safe HTML exports.
 
 ### Cost & Usage Tracking
 


### PR DESCRIPTION
Adds BrowserTrace to the LLM & AI Observability instrumentation section.\n\nBrowserTrace is a local-first trace viewer for AI browser-agent failures. It captures screenshots, URLs, actions, model input/output, status, errors, and public-safe HTML exports, so it fits the section's agent workflow debugging scope.\n\nValidation:\n- Confirmed BrowserTrace is not already listed in this repo.\n- Checked the contribution guidelines.\n- Ran `git diff --check`.