### PR TITLE
Add observability-mcp to Anomalies Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Tools for rocessing the system data.
 - [Prophet](https://facebook.github.io/prophet/) - Forecasting procedure implemented in R and Python. It is fast and provides completely automated forecasts that can be tuned by hand by data scientists and analysts.
 - [Anomaly Detection Toolkit (ADTK)](https://adtk.readthedocs.io/en/stable/) - Python package for unsupervised / rule-based time series anomaly detection.
 - [Chaos Genius](https://github.com/chaos-genius/chaos_genius) - ML powered analytics engine for anomaly/outlier detection and root cause analysis.
+- [observability-mcp](https://github.com/ThoTischner/observability-mcp) - Cross-signal anomaly detection (z-score) over Prometheus metrics and Loki logs, exposed to AI agents through the Model Context Protocol. Pluggable connectors for additional backends, weighted health scoring, Web UI, and an ArtifactHub-listed Helm chart.
 
 ## 10. LLM & AI Observability
 


### PR DESCRIPTION
Adds **observability-mcp** to section 9 / Anomalies Detection.

It's a cross-signal anomaly detector (z-score over Prometheus metrics + Loki logs) exposed through the [Model Context Protocol](https://modelcontextprotocol.io/) so AI agents call it directly — no PromQL / LogQL required from operators. Pluggable connector interface so additional backends (Datadog, Elastic, Mimir, etc.) can be added without forking.

- MIT-licensed, [GitHub repo](https://github.com/ThoTischner/observability-mcp)
- npm: `@thotischner/observability-mcp`
- Container: `ghcr.io/thotischner/observability-mcp` (multi-arch, SBOM + SLSA provenance)
- Helm chart on ArtifactHub (signed packages, NetworkPolicy, ServiceMonitor, values.schema.json)
- Airgapped deployment supported

Single-line diff, alphabetical position respected, no other changes.