### PR TITLE
Add piqc — model-aware GPU waste scanner for Kubernetes inference clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.
 - [Burnd](https://github.com/garvitsurana/burnd) - Local-first CLI that reads Claude Code JSONL session files and surfaces cost leaks via pattern detectors (retry storms, tool overuse, repeated reads, thrash, etc.). npx-installable, MIT, zero telemetry; findings export to a shareable report URL.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
+- [piqc](https://github.com/paralleliq/piqc) - Open-source GPU waste scanner for Kubernetes inference clusters. Surfaces tier misplacement, idle capacity, and OOM risk — each quantified in dollars — for teams optimizing GPU inference spend.
 
 ## 11. GPU Observability
 
@@ -427,6 +428,7 @@ As GPU workloads become central to AI/ML production systems, observability at th
 - [nvidia_gpu_exporter](https://github.com/utkuozdemir/nvidia_gpu_exporter) - Lightweight Prometheus exporter for NVIDIA GPUs using nvidia-smi. No DCGM or C bindings required. Works on Linux and Windows with auto-discovered metric fields and Grafana dashboard.
 - [nvitop](https://github.com/XuehaiPan/nvitop) - Interactive NVIDIA GPU process viewer with rich Python API. Ships nvitop-exporter for Prometheus metrics and Grafana dashboards, plus ResourceMetricCollector API for custom monitoring and ML framework callbacks.
 - [NVTOP](https://github.com/Syllo/nvtop) - Task monitor for GPUs and accelerators, similar to htop. Multi-vendor support: NVIDIA, AMD, Intel, Apple, Huawei Ascend, Qualcomm Adreno and more.
+- [piqc](https://github.com/paralleliq/piqc) - Open-source GPU waste scanner for Kubernetes inference clusters. Detects tier misplacement, idle capacity, OOM risk, and CPU:GPU imbalance — model-aware, read-only, deploys as a Kubernetes Job.
 
 ## 12. Application Performance Monitoring Solutions (APM)
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ As GPU workloads become central to AI/ML production systems, observability at th
 - [nvidia_gpu_exporter](https://github.com/utkuozdemir/nvidia_gpu_exporter) - Lightweight Prometheus exporter for NVIDIA GPUs using nvidia-smi. No DCGM or C bindings required. Works on Linux and Windows with auto-discovered metric fields and Grafana dashboard.
 - [nvitop](https://github.com/XuehaiPan/nvitop) - Interactive NVIDIA GPU process viewer with rich Python API. Ships nvitop-exporter for Prometheus metrics and Grafana dashboards, plus ResourceMetricCollector API for custom monitoring and ML framework callbacks.
 - [NVTOP](https://github.com/Syllo/nvtop) - Task monitor for GPUs and accelerators, similar to htop. Multi-vendor support: NVIDIA, AMD, Intel, Apple, Huawei Ascend, Qualcomm Adreno and more.
+- [piqc](https://github.com/paralleliq/piqc) - Model-aware GPU waste scanner for Kubernetes inference clusters. Detects tier misplacement, idle capacity, OOM risk, and CPU:GPU imbalance, each quantified in dollars. Read-only, deploys as a Kubernetes Job.
 
 ## 12. Application Performance Monitoring Solutions (APM)
 


### PR DESCRIPTION
**[piqc](https://github.com/paralleliq/piqc)** is an open-source, read-only GPU waste scanner for Kubernetes inference clusters.

Unlike existing GPU observability tools that expose raw CUDA/Prometheus metrics, piqc is model-aware: it understands which model is running on which GPU, what tier it belongs on, and what the gap costs. It surfaces four waste patterns that typically account for 20-40% of GPU spend in production inference:

- **Tier misplacement** - model running on a GPU with more memory/compute than it needs
- **Dark capacity** - GPU allocated to a deployment serving no live traffic
- **OOM risk** - model approaching GPU memory ceiling
- **CPU:GPU imbalance** - CPU saturation throttling GPU throughput in agentic workloads

Deploys as a Kubernetes Job, requires no write permissions, exits after reporting. Apache 2.0.

Added to two sections:
- **Section 11 GPU Observability** - focused on waste patterns rather than raw metrics
- **Section 10 LLM & AI Observability > Cost & Usage Tracking** - each finding is quantified in dollars, making it directly actionable for teams managing inference spend
