### PR TITLE
Add Voight to LLM & AI Observability → Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.
 - [CueAPI](https://github.com/cueapi/cueapi-core) - Open-source observability for AI agent execution outcomes. Tracks verified vs. reported success rates, outcome timeouts, and verification-pending backlogs across scheduled agent work. Self-hosted, Apache-2.0.
+- [Voight](https://voight.xyz) - Real-time LLM observability platform. Drop-in SDK wrappers for OpenAI, Anthropic, Vercel AI SDK + hooks for Claude Code and Cursor capture prompts, tokens, cache reads, tool calls, cost, latency, and errors. OpenTelemetry-compatible via `otel: true` opt-in.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
Adds Voight to section 10 (LLM & AI Observability) → Platforms.

Real-time LLM observability platform — drop-in SDK wrappers around official OpenAI / Anthropic Node SDKs and the Vercel AI SDK capture every model call (prompts, tokens, cache reads, tool calls, cost, latency, errors). Hooks for Claude Code and Cursor extend coverage to coding-agent workflows. OpenTelemetry-compatible via `otel: true` opt-in flag.

- Homepage: https://voight.xyz
- npm packages: @voightxyz/sdk, @voightxyz/openai, @voightxyz/anthropic, @voightxyz/vercel-ai
- License: Apache 2.0