### PR TITLE
Add secure-log2test to Load Generators and Synthetic Traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ There are many more commands and methodologies you can apply to drill deeper.
 - [Pandora](https://github.com/yandex/pandora) - High-performance load generator in Go language. It has built-in HTTP(S) and HTTP/2 support and you can write your own load scenarios in Go, compiling them just before your test.
 - [Gatling](https://gatling.io/) - Load test as code.
 - [GoReplay](https://github.com/buger/goreplay) - Open-source tool for capturing and replaying live HTTP traffic into a test environment in order to continuously test your system with real data.
+- [secure-log2test](https://github.com/golikovichev/secure-log2test) - Python CLI that turns structured Kibana and Elasticsearch log exports into runnable pytest regression suites. Runs fully on-premises with no external API calls; auth headers and secret-looking body fields are redacted before output.
 - [phantom](https://github.com/yandex-load/phantom/tree/master/examples) - Evgeniy Mamchits' phantom is a very fast (100 000+ RPS) shooter written in C++ (default).
 - [BFG](https://github.com/yandex-load/bfg) - A modular tool and framework for load generation that supports HTTP/2.
 - [Bender](https://github.com/pinterest/bender) - Makes it easy to build load testing applications for services using protocols like HTTP, Thrift, Protocol Buffers and many more. Bender provides a library of flexible, powerful primitives that can be combined (with plain Go code) to build load testers customized to any use case and that evolve with your service over time.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ There are many more commands and methodologies you can apply to drill deeper.
 - [Pandora](https://github.com/yandex/pandora) - High-performance load generator in Go language. It has built-in HTTP(S) and HTTP/2 support and you can write your own load scenarios in Go, compiling them just before your test.
 - [Gatling](https://gatling.io/) - Load test as code.
 - [GoReplay](https://github.com/buger/goreplay) - Open-source tool for capturing and replaying live HTTP traffic into a test environment in order to continuously test your system with real data.
-- [secure-log2test](https://github.com/golikovichev/secure-log2test) - Python CLI that turns structured Kibana and Elasticsearch log exports into runnable pytest regression suites. Runs fully on-premises with no external API calls; auth headers and secret-looking body fields are redacted before output.
 - [phantom](https://github.com/yandex-load/phantom/tree/master/examples) - Evgeniy Mamchits' phantom is a very fast (100 000+ RPS) shooter written in C++ (default).
 - [BFG](https://github.com/yandex-load/bfg) - A modular tool and framework for load generation that supports HTTP/2.
 - [Bender](https://github.com/pinterest/bender) - Makes it easy to build load testing applications for services using protocols like HTTP, Thrift, Protocol Buffers and many more. Bender provides a library of flexible, powerful primitives that can be combined (with plain Go code) to build load testers customized to any use case and that evolve with your service over time.
@@ -351,6 +350,7 @@ Tools for rocessing the system data.
 <!--lint ignore double-link-->
 - [Haystack](https://expediadotcom.github.io/haystack/) - A resilient, scalable tracing and analysis system.
 - [Kapacitor](https://www.influxdata.com/time-series-platform/kapacitor/) - Real-time streaming data processing engine.
+- [secure-log2test](https://github.com/golikovichev/secure-log2test) - Python CLI that turns structured Kibana and Elasticsearch log exports into runnable pytest regression suites. Runs fully on-premises with no external API calls; auth headers and secret-looking body fields are redacted before output.
 
 ### Alerts
 


### PR DESCRIPTION
Adds secure-log2test to the Load Generators and Synthetic Traffic section, placed next to GoReplay since both use captured production data to drive testing (GoReplay replays HTTP traffic; secure-log2test emits pytest assertions from structured log exports).

secure-log2test is an MIT-licensed Python CLI. Input is a Kibana or Elasticsearch JSON export, output is a pytest module. The privacy-first design suits regulated environments: redaction runs before generation, so auth headers (Authorization, Cookie, X-API-Key, refresh-token) and secret-looking body fields (token, password, api_key, refresh_token) are replaced with `***REDACTED***` before they reach the output file. All processing is on-premises, no external API calls.

Stack: Python 3.10-3.13, Pydantic, Jinja2, GitHub Actions CI.

Repo: https://github.com/golikovichev/secure-log2test
PyPI: https://pypi.org/project/secure-log2test/

Happy to move it to a different section if Load Generators is not the right fit — Section 9 Processing was the other candidate.

code-reviewed