### PR TITLE
Add groundcover to Application Performance Monitoring Solutions (APM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [Sematext Cloud](https://sematext.com/) - Infrastructure, log, and digital experience monitoring with service and log auto-discovery. Basic plan is free.
 - [TraceKit](https://tracekit.dev) - Lightweight APM combining distributed tracing, live breakpoints, and session replay. Built on OpenTelemetry with SDKs for 13+ languages (frontend to backend).
 - [Apitally](https://apitally.io) - API monitoring, analytics, and request logging for REST APIs, with lightweight open-source SDKs for Python, Node.js, Go, .NET, and Java.
+- [groundcover](https://www.groundcover.com/) - eBPF-based observability platform for Kubernetes with logs, metrics, traces, and APM; deployed entirely inside the user's own cloud (BYOC) for data residency.
 
 ## 13. Service Mesh
 


### PR DESCRIPTION
Adding groundcover to §12 APM. It's a commercial eBPF-based observability platform for Kubernetes — logs, metrics, traces, and APM from a single DaemonSet sensor. The differentiator vs the other vendors in this section (Datadog, Honeycomb, NewRelic, Chronosphere, etc.) is the BYOC architecture: the entire data plane runs inside the customer's own cloud, so telemetry never leaves their VPC.

Slots naturally next to the existing eBPF entries in this section (DeepFlow, coroot, Pixie). Appended to the end of the section per the maintainer's usual flow.

Disclosure: I work at groundcover.