### PR TITLE
Add Heron to LLM & AI Observability › Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.
 - [CueAPI](https://github.com/cueapi/cueapi-core) - Open-source observability for AI agent execution outcomes. Tracks verified vs. reported success rates, outcome timeouts, and verification-pending backlogs across scheduled agent work. Self-hosted, Apache-2.0.
+- [Heron](https://github.com/Netis/heron) - Passive, SDK-free observability for LLM and agent traffic. Reconstructs agent turns and service topology from post-TLS HTTP on the wire — no SDK and no proxy in the request path. Decodes OpenAI/Anthropic/Gemini, folds multi-leg proxy hops, auto-classifies vLLM/SGLang/Ollama backends. Single static binary with embedded console, Apache-2.0.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
Adds **Heron** to the LLM & AI Observability → Platforms list.

[Heron](https://github.com/Netis/heron) is an open-source (Apache-2.0) platform that takes a different angle from the SDK/OpenTelemetry-based tools already listed: it's **passive** and **SDK-free**. It reads post-TLS HTTP traffic on the wire (on the inference host or from a SPAN/TAP), so it needs no code changes and never sits in the request path — the observer can fail without affecting the calls it watches.

What it adds beyond per-call tracing:
- Reconstructs multi-call **agent turns** (the whole plan/tool-call loop as one unit), not just individual calls
- Folds multi-leg proxy hops (client → litellm → vLLM/SGLang) into one row and auto-classifies backends from the bytes
- Decodes OpenAI Chat/Responses, Anthropic Messages, Gemini
- Single static binary with the web console embedded; Linux + macOS

- [x] Entry follows the existing `- [Name](link) - Description.` format
- [x] Placed in the most relevant section (Platforms)
- [x] Open-source, actively maintained, with a clear README