### PR TITLE
Add Oh Dear to Uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [OverOps](https://www.overops.com) - Provides Automated Root Cause (ARC) analysis to reduce the time to identify and fix critical production application errors.
 - [Freshping](https://freshping.io) - Free for 50 monitors, checked every 1 minutes. Status pages, monitoring of HTTP (and DNS, ICMP, TCP/UDP), select region of monitoring.
 - [FlareWarden](https://flarewarden.com) - Uptime, content, dependency, and SSL monitoring with multi-region verification and status pages. Free plan includes 15 monitors, 5-minute checks, and 90 days of history.
+- [Oh Dear](https://ohdear.app) - Uptime, performance, SSL certificate, broken link, and DNS monitoring, with hosted status pages.
 
 ## 9. Processing and Analyze and Act
 


### PR DESCRIPTION
Adds Oh Dear (https://ohdear.app) to the Uptime section. Oh Dear is a website monitoring SaaS covering uptime, performance, SSL certificates, broken links, DNS, scheduled tasks, and hosted status pages. It is not currently listed.