### PR TITLE
Add Lookspan to LLM & AI Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Helicone](https://github.com/Helicone/helicone) - Open source LLM observability platform and AI Gateway. One line of code to monitor, evaluate, and experiment across 100+ providers.
 - [OpenLIT](https://github.com/openlit/openlit) - OTel-native observability and evals for LLMs and GPUs.
 - [Langtrace](https://github.com/Scale3-Labs/langtrace) - Open source OpenTelemetry-based observability for LLM applications.
+- [Lookspan](https://github.com/JoniMartin27/lookspan) - Local-first observability for AI agents. One command (`npx lookspan`) runs a dashboard with traces, a timeline/waterfall view, cost tracking, replay & LLM-as-judge, and datasets. MCP-native, with OpenAI/Anthropic drop-ins and an OpenTelemetry receiver — all data stays on your machine.
 - [Opik](https://github.com/comet-ml/opik) - Debug, evaluate, and monitor LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards.
 - [Laminar](https://github.com/lmnr-ai/lmnr) - Open-source observability and analytics platform purpose-built for AI agents. Built in Rust for performance.
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.


### PR DESCRIPTION
Adds **Lookspan** to section 10 (LLM & AI Observability → Platforms).

[Lookspan](https://github.com/JoniMartin27/lookspan) is a local-first observability tool for AI agents: one command (`npx lookspan`) runs a dashboard with traces, a timeline/waterfall view, cost tracking, replay & LLM-as-judge, and datasets. It's MCP-native, ships drop-in wrappers for the OpenAI and Anthropic SDKs, and exposes an OpenTelemetry receiver — all data stays on the user's machine. MIT, TypeScript, on npm.

Follows the existing `- [name](url) - description.` bullet format in the Platforms list.