### PR TITLE
Add Seerlens to LLM & AI Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.
 - [CueAPI](https://github.com/cueapi/cueapi-core) - Open-source observability for AI agent execution outcomes. Tracks verified vs. reported success rates, outcome timeouts, and verification-pending backlogs across scheduled agent work. Self-hosted, Apache-2.0.
+- [Seerlens](https://github.com/eladser/seerlens) - Local-first, .NET-first observability and evals for LLM apps. Live tracing, cost in dollars against a budget, CI-gateable evals, and agent/MCP tool-call scoring. Built on OpenTelemetry with .NET, Python and JS SDKs.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
Adds [Seerlens](https://github.com/eladser/seerlens) to the LLM & AI Observability > Platforms list.

Seerlens is a local-first, .NET-first observability and eval tool for LLM apps: live prompt/cost/latency tracing, cost in dollars against a budget, CI-gateable evals (keyword, LLM-as-judge, and agent tool-call scoring), and MCP tool-call visibility. Built on the OpenTelemetry GenAI conventions with .NET, Python and JS SDKs. MIT licensed. Fits alongside the existing Langfuse / Phoenix / Helicone / Opik entries, with the distinction of being local-first and the only one native to .NET.