### PR TITLE
Add KnoxOps to LLM & AI Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.
 - [CueAPI](https://github.com/cueapi/cueapi-core) - Open-source observability for AI agent execution outcomes. Tracks verified vs. reported success rates, outcome timeouts, and verification-pending backlogs across scheduled agent work. Self-hosted, Apache-2.0.
+- [KnoxOps](https://knoxops.app/?invite_token=GITHUB26) - AI-native ops agent that gives AI coding agents production-safe execution with human review gating and a built-in knowledge graph.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
AI-native ops agent that gives AI coding agents production-safe execution with human review gating and a built-in knowledge graph.

Added to the Platforms sub-section under LLM & AI Observability. Currently invite-only — the invite_token=GITHUB26 provides instant access for reviewers.