### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.
 - [CueAPI](https://github.com/cueapi/cueapi-core) - Open-source observability for AI agent execution outcomes. Tracks verified vs. reported success rates, outcome timeouts, and verification-pending backlogs across scheduled agent work. Self-hosted, Apache-2.0.
+- [Future AGI](https://github.com/future-agi/future-agi) - Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
This PR adds Future AGI to this list in the **LLM & AI Observability platforms** section.

[Future AGI](https://github.com/future-agi/future-agi) is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.