### PR TITLE
Add HomeLab Monitor to GPU Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 
 As GPU workloads become central to AI/ML production systems, observability at the GPU level has emerged as a discipline of its own. Unlike traditional APM, GPU observability focuses on __CUDA tracing__, __causal chain analysis__ linking host kernel events to GPU latency, and __zero-config eBPF instrumentation__ for always-on production use.
 
+- [HomeLab Monitor](https://github.com/SikamikanikoBG/homelab-monitor) - Self-hosted dashboard that shows which Docker container is actually holding the GPU - per-container VRAM attribution, not just total utilization. Also covers host vitals, Docker health, systemd services, and multiple machines over SSH. MIT license.
 - [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA Runtime/Driver APIs via uprobes and host kernel events via tracepoints to build 4-layer causal chains explaining GPU latency in production. Zero-config, <2% overhead, OTLP/Prometheus export, Kubernetes-native.
 - [NVIDIA DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) - Official NVIDIA Prometheus exporter for GPU metrics via DCGM. Kubernetes-native with Helm support, Grafana dashboards, per-process GPU metrics, MIG support, and TLS/auth.
 - [nvidia_gpu_exporter](https://github.com/utkuozdemir/nvidia_gpu_exporter) - Lightweight Prometheus exporter for NVIDIA GPUs using nvidia-smi. No DCGM or C bindings required. Works on Linux and Windows with auto-discovered metric fields and Grafana dashboard.


### PR DESCRIPTION
Adds HomeLab Monitor to the GPU Observability section.

HomeLab Monitor is a self-hosted dashboard that runs as a single Docker container and shows which container is actually holding the GPU - per-container VRAM attribution, not just total GPU utilization. If you run Ollama, ComfyUI, and a training job at the same time, it tells you which process owns the card and how much VRAM each one holds.

It also covers Docker container health, systemd service status, host vitals (CPU/RAM/disk/temps), and multiple machines over SSH from one dashboard. Since v0.14.0 it ships with a built-in read-only MCP server, so AI agents can query the homelab. MIT license, Python, actively maintained.

Placement: alphabetically first in the section (H sorts before I for Ingero).
