### PR TITLE
Add Grafana Alloy to Collect → Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ There are many more commands and methodologies you can apply to drill deeper.
 
 <!--lint ignore double-link-->
 - [Elastic Beats](https://github.com/elastic/beats) - Lightweight shippers for Elasticsearch & Logstash, Elastic stack.
+- [Grafana Alloy](https://github.com/grafana/alloy) - Grafana's OpenTelemetry Collector distribution that unifies logs, metrics, and traces in a single agent; the supported successor to Promtail and Grafana Agent.
 - [mTAIL](http://ophilipp.free.fr/op_tail.htm) - Windows program that extract internal monitoring data from application logs for collection in a timeseries database.
 
 ### Events & Problems


### PR DESCRIPTION
## What

Adds **[Grafana Alloy](https://github.com/grafana/alloy)** to **Collect → Logging**, placed alphabetically between *Elastic Beats* and *mTAIL*.

## Why

Alloy is currently **missing from the entire list**, which is a notable gap:

- It's Grafana's **OpenTelemetry Collector distribution** — one agent for logs, metrics, and traces.
- It's the **supported successor to both Promtail and Grafana Agent**, both of which are now EOL/deprecated. Loki is already listed, but the agent Grafana now points everyone to for shipping into it is not.

The entry follows the existing format (single link, trailing period). Single link, so no `lint ignore` directive needed.

- [x] Made sure the entry is in the most relevant section
- [x] Searched the list to confirm it isn't already present
- [x] Format matches the surrounding entries
