### PR TITLE
Add ax to LLM observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.
 - [Burnd](https://github.com/garvitsurana/burnd) - Local-first CLI that reads Claude Code JSONL session files and surfaces cost leaks via pattern detectors (retry storms, tool overuse, repeated reads, thrash, etc.). npx-installable, MIT, zero telemetry; findings export to a shareable report URL.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
+- [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
## Summary

Add ax to the LLM & AI Observability section as a local telemetry tool for AI coding agents.

## Verification

- `git diff --check`
- `curl -I -L --max-time 20 https://github.com/Necmttn/ax`
- `npx -y markdownlint-cli2 README.md` (unchanged upstream baseline: 300 errors)

---

_Generated with [ax](https://github.com/Necmttn/ax)._