### PR TITLE
Add Preflight to Cost & Usage Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.
 - [Burnd](https://github.com/garvitsurana/burnd) - Local-first CLI that reads Claude Code JSONL session files and surfaces cost leaks via pattern detectors (retry storms, tool overuse, repeated reads, thrash, etc.). npx-installable, MIT, zero telemetry; findings export to a shareable report URL.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
+- [Preflight](https://github.com/newrelic-experimental/preflight) - Local-first observability for AI coding assistants. Captures every tool call (reads, edits, commands, searches), tracks USD cost per session/day/week and per model, scores efficiency, and detects anti-patterns (re-reads, blind edits, stuck loops) on a live local dashboard. Offline by default, Apache-2.0; optional New Relic backend for team rollups and alerting. Works with Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, and Amazon Q.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
Adds **Preflight** under **10. LLM & AI Observability → Cost & Usage Tracking**, alongside the existing peers there (Burnd, agenttrace, burn0).

Preflight is open-source (Apache-2.0), local-first observability for AI coding assistants. It captures every tool call the agent makes (reads, edits, commands, searches), tracks USD cost per session/day/week and per model, scores efficiency, and detects anti-patterns (re-reads, blind edits, stuck loops) on a live local dashboard — offline by default, no account required. Works with Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, and Amazon Q.

- Repo: https://github.com/newrelic-experimental/preflight
- License: Apache-2.0

**Disclosure:** I'm involved with the project; it's maintained by New Relic. The tool is fully functional offline with no signup; the optional, opt-in New Relic backend adds team rollups and alerting. Listed in the local-first/cost-tracking group to match how it's actually used.
