### PR TITLE
Add OpenChainBench to Examples and Sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [Spring PetClinic Sample Application](https://github.com/spring-petclinic/spring-petclinic-microservices) - Distributed version of the Spring PetClinic Sample Application built with Spring Cloud.
 - [My Spring PetClinic Sample Application](https://github.com/adriannovegil/spring-petclinic-microservices-sre) - My fork of the official repository.
 - [FastAPI with Observability](https://github.com/Blueswen/fastapi-observability) - Docker ready. Telemetry FastAPI application with three pillars of observability: Traces (Tempo), Metrics (Prometheus), Logs (Loki) on Grafana through OpenTelemetry and OpenMetrics. Using examplar for cross querying between traces, metrics and logs.
+- [OpenChainBench](https://github.com/ChainBench/OpenChainBench) - Open benchmark stack for blockchain RPC providers. Multi-region harnesses scrape live tx-landing, latency and finality metrics; Next.js front-end exposes the dashboards and the raw Prometheus data ([website](https://openchainbench.com)).
 
 ## 16. References
 


### PR DESCRIPTION
Adds OpenChainBench under section 15 (Examples and Sandboxes). It is an open observability stack (Prometheus + Next.js) running continuous benchmarks of blockchain RPC providers with multi-region probes. Methodology and harness code are open source.

Thanks for maintaining the list.