### PR TITLE
Add Tuning Engines to LLM and AI observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [OpenLIT](https://github.com/openlit/openlit) - OTel-native observability and evals for LLMs and GPUs.
 - [Langtrace](https://github.com/Scale3-Labs/langtrace) - Open source OpenTelemetry-based observability for LLM applications.
 - [Opik](https://github.com/comet-ml/opik) - Debug, evaluate, and monitor LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards.
+- [Tuning Engines](https://github.com/cerebrixos-org/tuningengines) - OpenAI-compatible control plane for governed inference with agent and MCP traces, policy decisions, approval workflows, and usage or cost visibility across external runtimes.
 - [Laminar](https://github.com/lmnr-ai/lmnr) - Open-source observability and analytics platform purpose-built for AI agents. Built in Rust for performance.
 - [Agenta](https://github.com/Agenta-AI/agenta) - Open-source LLMOps platform for prompt playground, prompt management, LLM evaluation, and observability.
 - [Pydantic Logfire](https://github.com/pydantic/logfire) - AI observability platform for production LLM and agent systems. Built on OpenTelemetry with first-class Pydantic AI support.


### PR DESCRIPTION
## Summary\n- add Tuning Engines to the LLM & AI Observability platforms section\n\n## Why\nThis section already collects tooling around prompt tracing, token and cost visibility, evaluation, and agent workflow debugging. Tuning Engines is a good fit as an OpenAI-compatible control plane for governed inference, agent and MCP traces, approval workflows, and runtime usage visibility.