### PR TITLE
Add logden to Collector > Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [logdy](https://github.com/logdyhq/logdy-core) - Supercharge terminal logs with web browser UI and low-code. It's like jq, tail, less, grep and awk merged together and available in a clean UI. Self-hosted, single binary.
 - [Last9](https://last9.io/docs/logs/) - Unified Logs Explorer with search, filters, SQL query support, and OpenTelemetry-native ingestion.
 - [PFC-JSONL](https://github.com/ImpossibleForge/pfc-jsonl) - Specialized JSONL log compressor with block-level timestamp indexing for efficient log storage. ~9% compression ratio with Fluent Bit integration and DuckDB queryable archives.
+- [logden](https://github.com/ginkida/logden) - Compact centralized logging gateway that ingests logs over HTTP into a Go stdlib service and stores them in ClickHouse, built to run on a ~1 GB RAM VPS.
 
 ### Events
 


### PR DESCRIPTION
Adding logden, a compact self-hosted logging gateway: it ingests logs over HTTP into a small Go stdlib service and stores them in ClickHouse, designed to run comfortably on a ~1 GB RAM VPS. MIT-licensed, Docker image on ghcr. Fits alongside the other centralized log collectors in this section.