### PR TITLE
Add sunwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [Drumbeats](https://drumbeats.io) - Cron, heartbeat, and HTTP uptime monitoring for background jobs and services, with duration/hang alerts, concurrent-job correlation, incident management, and hosted status pages. Free for up to 50 monitors, 200K Beats/mo, no credit card. One curl ping instruments a job; no agent or SDK.
 - [Hyperping](https://hyperping.com) - Uptime, API, cron, and server monitoring from 18 locations, with on-call scheduling, escalation policies, and hosted status pages.
 - [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini). Free REST API at /api/v1/statuses, email/webhook alerts, 30-day uptime history.
+- [sunwatch](https://sunwatch.sunfamily.xyz) - Crypto-paid uptime monitoring for side projects. 3 free monitors; extras are $1/monitor/month via USDC on Base. Webhook alerts on down/up state changes. Open source.
 
 ## 9. Processing and Analyze and Act
 


### PR DESCRIPTION
Add [sunwatch](https://sunwatch.sunfamily.xyz) to the uptime monitoring section.

- 3 free monitors with 1-minute checks and webhook alerts
- Paid extras at $1/monitor/month via USDC on Base
- No account or KYC required
- [Source](https://github.com/ryan-knowone/sunwatch)