### PR TITLE
feat(monitoring): add Prismix AI service status monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [Oh Dear](https://ohdear.app) - Uptime, performance, SSL certificate, broken link, and DNS monitoring, with hosted status pages.
 - [Drumbeats](https://drumbeats.io) - Cron, heartbeat, and HTTP uptime monitoring for background jobs and services, with duration/hang alerts, concurrent-job correlation, incident management, and hosted status pages. Free for up to 50 monitors, 200K Beats/mo, no credit card. One curl ping instruments a job; no agent or SDK.
 - [Hyperping](https://hyperping.com) - Uptime, API, cron, and server monitoring from 18 locations, with on-call scheduling, escalation policies, and hosted status pages.
+- [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini). Free REST API at /api/v1/statuses, email/webhook alerts, 30-day uptime history.
 
 ## 9. Processing and Analyze and Act
 


### PR DESCRIPTION
## What

Adds **Prismix** to the monitoring section — real-time uptime tracking and incident history for 75+ AI services (OpenAI, Anthropic, Google Gemini, Cursor, Groq, Mistral, and more).

## Why it fits

Observability practitioners increasingly monitor AI APIs as first-class dependencies. Prismix provides:
- Real-time status for 75+ AI/LLM services
- 30-day uptime history and incident timelines
- Free REST API: `GET https://prismix.dev/api/v1/statuses`
- Email/webhook alerts for status changes

## Entry added

**Monitoring** section:
```
- [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini). Free REST API at /api/v1/statuses, email/webhook alerts, 30-day uptime history.
```