### PR TITLE
Add SourceryKit to LLM & AI Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [Drumbeats](https://drumbeats.io) - Cron, heartbeat, and HTTP uptime monitoring for background jobs and services, with duration/hang alerts, concurrent-job correlation, incident management, and hosted status pages. Free for up to 50 monitors, 200K Beats/mo, no credit card. One curl ping instruments a job; no agent or SDK.
 - [Hyperping](https://hyperping.com) - Uptime, API, cron, and server monitoring from 18 locations, with on-call scheduling, escalation policies, and hosted status pages.
 - [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini). Free REST API at /api/v1/statuses, email/webhook alerts, 30-day uptime history.
+- [sunwatch](https://sunwatch.sunfamily.xyz) - Crypto-paid uptime monitoring for side projects. 3 free monitors; extras are $1/monitor/month via USDC on Base. Webhook alerts on down/up state changes. Open source.
 
 ## 9. Processing and Analyze and Act
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Voight](https://voight.xyz) - Real-time LLM observability platform. Drop-in SDK wrappers for OpenAI, Anthropic, Vercel AI SDK + hooks for Claude Code and Cursor capture prompts, tokens, cache reads, tool calls, cost, latency, and errors. OpenTelemetry-compatible via `otel: true` opt-in.
 - [Latitude](https://github.com/latitude-dev/latitude-llm) - Open-source LLM observability and evaluation platform. Traces, monitors, and evaluates AI agents in production, clusters failures into issues, and generates evals from real-world failures. Built on OpenTelemetry with OpenInference and OpenLLMetry support.
 - [telemetry.dev](https://telemetry.dev) - OpenTelemetry-native observability for LLM and agent apps: per-span tokens, cost, latency, and errors from any OTLP exporter.
+- [SourceryKit](https://github.com/ProvablyAI/sourcerykit) - Observability and governance for AI agent egress. Logs every outbound request and MCP handoff and verifies each against a source of truth with a zero-knowledge proof, blocking anything not on the trusted allow-list. Python SDK (source-available) with a hosted verification backend.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
Hi, thanks for maintaining this, the LLM & AI Observability section is a great roundup. Adding one that fits alongside Traccia and CueAPI.

SourceryKit gives observability and governance over what an AI agent sends out. It logs every outbound request and MCP handoff, and verifies each against a source of truth with a zero-knowledge proof before the call leaves, blocking anything not on the trusted allow-list. That gives a verifiable record of agent egress, not just a trace.

It is a Python SDK (source-available), paired with a hosted backend that runs the verification. Kept the entry to one line in the section format.

Thanks for taking a look.