### PR TITLE
Add DataBuff to APM Solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ As GPU workloads become central to AI/ML production systems, observability at th
 
 - [servicenow - Cloud Observability](https://www.servicenow.com/products/observability.html) - Gain AI-powered insights to detect and quickly respond to changes in cloud-native and monolithic applications.
 - [DeepFlow](https://github.com/deepflowio/deepflow) - Implemented Zero Code data collection with eBPF for metrics, distributed tracing, request logs and function profiling, and is further integrated with SmartEncoding to achieve Full Stack correlation and efficient access to all observability data.
+- [DataBuff](https://github.com/databufflabs/databuff) - Open-source AI-native OpenTelemetry APM. Ingests OTLP traces, metrics, and logs and exposes an LLM-powered multi-agent workspace (with MCP support) for querying traces, service topology, RED metrics, and alerts in natural language.
 - [coroot](https://coroot.com/) - Open-source eBPF-based observability tool that turns telemetry data into actionable insights, helping you identify and resolve application issues quickly.
 - [robusta](https://home.robusta.dev/) - Unified Kubernetes  monitoring, observability, and operations.
 - [Odigos](https://github.com/keyval-dev/odigos) - Observability Control Plane.


### PR DESCRIPTION
Add DataBuff — an open-source AI-native OpenTelemetry APM — to the APM Solutions section.

DataBuff natively ingests OTLP traces, metrics, and logs and exposes an LLM-powered multi-agent workspace (with MCP support) for querying traces, service topology, RED metrics, and alerts in natural language. It fits naturally alongside the other open-source APMs already listed here (DeepFlow, coroot, SigNoz, SkyWalking, …).

- Followed the existing entry format: `- [Name](url) - description`
- Single-line addition, no other content touched
- Description focuses on the OpenTelemetry / OTLP angle, no marketing fluff

Made with [Cursor](https://cursor.com)