### PR TITLE
Add rrweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [Apitally](https://apitally.io) - API monitoring, analytics, and request logging for REST APIs, with lightweight open-source SDKs for Python, Node.js, Go, .NET, and Java.
 - [groundcover](https://www.groundcover.com/) - eBPF-based observability platform for Kubernetes with logs, metrics, traces, and APM; deployed entirely inside the user's own cloud (BYOC) for data residency.
 - [CoreDash](https://coredash.app) - Real user monitoring for Core Web Vitals (LCP, INP, CLS, TTFB, FCP) with element level attribution, phase breakdowns, LoAF data, and a built in MCP server for AI agents. EU hosted, GDPR compliant.
+- [rrweb](https://github.com/rrweb-io/rrweb) - Open-source session replay library that records the DOM and user interactions as a typed JSON event stream and replays them. Powers the session replay features of Sentry, PostHog, Amplitude, and Highlight.
 
 ## 13. Service Mesh
 


### PR DESCRIPTION
Adds rrweb under 12. Application Performance Monitoring Solutions (APM).

rrweb is the open-source library that records the DOM and user interactions in the browser and replays them. It is the engine behind the session replay features of several commercial observability products: Sentry, Amplitude, and Highlight maintain public rrweb forks (getsentry/rrweb, amplitude/rrweb, highlight/rrweb), and PostHog documents rrweb as the basis of its session recording. Sentry is already in this section; listing rrweb gives readers the underlying building block.

- Repo: https://github.com/rrweb-io/rrweb (19,899 stars, MIT)
- Docs: https://rrweb.com/docs/

Disclosure: I work on rrweb.
