### PR TITLE
Add Aether to LLM and AI observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 
 ### Cost & Usage Tracking
 
+- [Aether](https://github.com/connectchiragg/aether) - Local observability TUI for Claude Code and Codex. Tracks context, cost, tokens, duration, tools, compactions, agents, code changes, and per-request input attribution from provider-local session files.
 - [Manifest](https://github.com/mnfst/manifest) - Open-source real-time cost observability for AI agents. Tracks tokens, costs, messages, and model usage. Self-hostable, privacy-focused, and OTLP-native.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers. Background daemon with SQLite storage, Material Design 3 web dashboard, and zero telemetry.
 - [burn0](https://github.com/burn0-dev/burn0) - Open-source Node.js cost observability with one import. Auto-detects and tracks per-request costs for 50+ services (LLMs, SaaS, databases) via HTTP interception. Sub-millisecond overhead, local-first with optional cloud dashboard.


### PR DESCRIPTION
## Summary

- add Aether to LLM & AI Observability under Cost & Usage Tracking
- describe its local, provider-session-based metrics and attribution

## Validation

- checked the repository link and MIT license
- matched the existing entry format
- ran `git diff --check`
