### PR TITLE
Add grafana-llmops-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
 - [Preflight](https://github.com/newrelic-experimental/preflight) - Local-first observability for AI coding assistants. Captures every tool call (reads, edits, commands, searches), tracks USD cost per session/day/week and per model, scores efficiency, and detects anti-patterns (re-reads, blind edits, stuck loops) on a live local dashboard. Offline by default, Apache-2.0; optional New Relic backend for team rollups and alerting. Works with Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, and Amazon Q.
 - [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
+- [grafana-llmops-forge](https://github.com/alebgl77/grafana-llmops-forge) - CLI that generates AI/LLM observability dashboards from an existing Grafana, covering FinOps by provider, agents/RAG, and EU AI Act governance. Zero-dependency.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
Adds [grafana-llmops-forge](https://github.com/alebgl77/grafana-llmops-forge) — Turn any Grafana into an AI/LLM observability suite — auto-discovery, generated dashboards (FinOps by provider sovereignty, agents/RAG, EU AI Act governance), vision-verified rendering. Zero-dependency CLI + Agent Skill.

Placed in the matching section, formatted per existing entries (insert l.434 (fin de section)). Author here — happy to adjust wording or placement.