### PR TITLE
Add whatbroke to LLM & AI Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
 - [Preflight](https://github.com/newrelic-experimental/preflight) - Local-first observability for AI coding assistants. Captures every tool call (reads, edits, commands, searches), tracks USD cost per session/day/week and per model, scores efficiency, and detects anti-patterns (re-reads, blind edits, stuck loops) on a live local dashboard. Offline by default, Apache-2.0; optional New Relic backend for team rollups and alerting. Works with Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, and Amazon Q.
 - [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - CLI that diffs an AI agent's behavior between two runs, covering tool calls, arguments, cost and latency. Imports OTLP GenAI span exports, Langfuse and LangSmith dumps. npx-installable, MIT.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
Adding whatbroke, a CLI I built that diffs an AI agent's behavior between two runs: tool calls dropped or added, arguments changed, outputs flipped, and cost and latency moves. It imports OTLP GenAI span exports plus Langfuse and LangSmith dumps, and runs via npx under an MIT license. I placed it in Cost & Usage Tracking next to the other small agent CLIs like Burnd and agenttrace.