### PR TITLE
Add telemetry.dev to LLM & AI Observability platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [Heron](https://github.com/Netis/heron) - Passive, SDK-free observability for LLM and agent traffic. Reconstructs agent turns and service topology from post-TLS HTTP on the wire — no SDK and no proxy in the request path. Decodes OpenAI/Anthropic/Gemini, folds multi-leg proxy hops, auto-classifies vLLM/SGLang/Ollama backends. Single static binary with embedded console, Apache-2.0.
 - [Voight](https://voight.xyz) - Real-time LLM observability platform. Drop-in SDK wrappers for OpenAI, Anthropic, Vercel AI SDK + hooks for Claude Code and Cursor capture prompts, tokens, cache reads, tool calls, cost, latency, and errors. OpenTelemetry-compatible via `otel: true` opt-in.
 - [Latitude](https://github.com/latitude-dev/latitude-llm) - Open-source LLM observability and evaluation platform. Traces, monitors, and evaluates AI agents in production, clusters failures into issues, and generates evals from real-world failures. Built on OpenTelemetry with OpenInference and OpenLLMetry support.
+- [telemetry.dev](https://telemetry.dev) - OpenTelemetry-native observability for LLM and agent apps: per-span tokens, cost, latency, and errors from any OTLP exporter.
 
 ### Instrumentation & SDKs
 


### PR DESCRIPTION
Adds one entry to `## 10. LLM & AI Observability` → `### Platforms`.

[telemetry.dev](https://telemetry.dev) is an OpenTelemetry-native observability platform for LLM and agent applications. Any OTLP/HTTP exporter can send to it, and it follows the OpenTelemetry GenAI semantic conventions. It records per-span token counts, cost (computed server-side from real token usage against 4,700+ model prices), latency, and errors. First-party TypeScript SDKs are on npm (`@telemetry-dev/sdk`, `@telemetry-dev/ai-sdk` as a Vercel AI SDK drop-in, `@telemetry-dev/otel`); LangChain in Python works over plain OTLP.

It is a commercial SaaS with a free tier (10k spans/month), consistent with other hosted platforms already listed in this subsection such as ClevAgent, Traccia, Respan, and Voight.

Single-line diff, no other changes. The link does not appear elsewhere in the README, so no `double-link` lint exception is required.

Disclosure: I'm the author of telemetry.dev.