### PR TITLE
Add agent-cost-guardrails to Cost & Usage Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Tracks cost, tokens, tool failures, anomalies, health, and CI gates across Claude Code, Codex, Gemini CLI, Aider, and Cursor exports.
 - [Preflight](https://github.com/newrelic-experimental/preflight) - Local-first observability for AI coding assistants. Captures every tool call (reads, edits, commands, searches), tracks USD cost per session/day/week and per model, scores efficiency, and detects anti-patterns (re-reads, blind edits, stuck loops) on a live local dashboard. Offline by default, Apache-2.0; optional New Relic backend for team rollups and alerting. Works with Claude Code, Cursor, Windsurf, Copilot, Zed, Continue.dev, and Amazon Q.
 - [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
+- [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - Hard token/cost budget enforcement and circuit breakers for multi-agent frameworks (CrewAI, AutoGen, LangGraph). Raises `BudgetExceededError` before a run starts and stops in-flight agents when limits are hit. MIT license, Python library.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
Adds [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) to the **Cost & Usage Tracking** subsection under LLM & AI Observability.

**What it does**: Hard token/cost budget enforcement and circuit breakers for multi-agent frameworks (CrewAI, AutoGen, LangGraph). Raises `BudgetExceededError` before a run starts and stops in-flight agents when limits are hit.

**Why it fits**: The existing entries in Cost & Usage Tracking track and surface cost data. This library actively enforces budget limits — a complementary enforcement layer rather than an observation layer. It is open-source (MIT), Python, and targets the same developer audience building LLM-powered agent systems.