### PR TITLE
Add App Health to Application Performance Monitoring Solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [groundcover](https://www.groundcover.com/) - eBPF-based observability platform for Kubernetes with logs, metrics, traces, and APM; deployed entirely inside the user's own cloud (BYOC) for data residency.
 - [CoreDash](https://coredash.app) - Real user monitoring for Core Web Vitals (LCP, INP, CLS, TTFB, FCP) with element level attribution, phase breakdowns, LoAF data, and a built in MCP server for AI agents. EU hosted, GDPR compliant.
 - [rrweb](https://github.com/rrweb-io/rrweb) - Open-source session replay library that records the DOM and user interactions as a typed JSON event stream and replays them. Powers the session replay features of Sentry, PostHog, Amplitude, and Highlight.
+- [App Health](https://github.com/sass-maker/app-health) - Privacy-first endpoint health for Node, Go, and OpenTelemetry services; projects only method, normalized route, status, duration, timestamp, and optional release into aggregate views.
 
 ## 13. Service Mesh
 


### PR DESCRIPTION
Adds App Health to the Application Performance Monitoring Solutions (APM) section.

App Health is an open-source, privacy-first endpoint-health dashboard for Node, Go, and OpenTelemetry services. It projects a deliberately small request shape into aggregate endpoint views instead of retaining raw request content or identity data. The single-line entry follows the surrounding list format and links to the public source repository.