### PR TITLE
Update stale service count on the API Status Check entry (Uptime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 
 ### Uptime
 
-- [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring for 120+ developer APIs including AWS, Stripe, GitHub, OpenAI, and more. Track third-party API availability with alerts and status pages.
+- [API Status Check](https://apistatuscheck.com) - Free real-time status monitoring for 285 developer APIs across 29 categories, including AWS, Stripe, GitHub, and OpenAI. Track third-party API availability with alerts and status pages.
 - [BlueWave Uptime](https://github.com/bluewave-labs/bluewave-uptime) - Open-source, self-hosted monitoring tool built with React.js, Node.js, and MongoDB, designed to track server uptime, response times, and incidents in real-time with beautiful visualizations.
 - [Monitive](http://monitive.com) - Free for 1 service, checked every 10 minutes with unlimited email & twitter alerts.
 - [UptimeRobot](https://uptimerobot.com) - Free for 50 monitors, checked every 5 minutes.


### PR DESCRIPTION
The `API Status Check` entry under **8. Visualization → Uptime** says "120+ developer APIs". The catalogue has grown since that entry was added; the current figure is 285 across 29 categories, verifiable from the site's public JSON feed:

```
$ curl -s https://apistatuscheck.com/api/status | jq '{count, categories: (.categories|length)}'
{ "count": 285, "categories": 29 }
```

One-line change, no new entry, link unchanged and still 200.