### PR TITLE
Add MB3R Stack to Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Tools for rocessing the system data.
 - [Haystack](https://expediadotcom.github.io/haystack/) - A resilient, scalable tracing and analysis system.
 - [Kapacitor](https://www.influxdata.com/time-series-platform/kapacitor/) - Real-time streaming data processing engine.
 - [secure-log2test](https://github.com/golikovichev/secure-log2test) - Python CLI that turns structured Kibana and Elasticsearch log exports into runnable pytest regression suites. Runs fully on-premises with no external API calls; auth headers and secret-looking body fields are redacted before output.
+- [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) - Model-based resilience toolchain combining telemetry-driven topology discovery with virtual failure simulation for continuous resilience assessment and pre-release analysis.
 
 ### Alerts
 


### PR DESCRIPTION
## Summary

Adds [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) to **Processing**.

MB3R Stack is an open-source model-based resilience toolchain that uses observability data to build an analyzable representation of a distributed system and evaluate virtual failure scenarios.

The stack combines:

* **Bering** — derives topology and model artifacts from trace/OTLP evidence and can publish rolling snapshots as the observed system changes.
* **Sheaft** — evaluates failure scenarios over those artifacts and produces resilience posture, risk analysis, and optional release-gate decisions.

This makes the stack a processing and analysis layer on top of observability data: telemetry is transformed into a system model and then into predictive resilience signals that can be used continuously, before releases, or to prioritize live chaos experiments.

### Research evidence

The underlying model-discovery and simulation approach has been evaluated against live fault-injection experiments in two published studies:

* [Model Discovery and Graph Simulation: A Lightweight Gateway to Chaos Engineering](https://conf.researchr.org/details/icse-2026/icse-2026-nier/25/Model-Discovery-and-Graph-Simulation-A-Lightweight-Gateway-to-Chaos-Engineering) — ICSE-NIER 2026, Distinguished Paper Award; evaluated on DeathStarBench.
* [Refining Resilience Model Discovery: A Case Study on the Limited Role of Asynchronous Edges in the OpenTelemetry Demo](https://link.springer.com/chapter/10.1007/978-3-032-23304-2_24) — AINA 2026; evaluated raw OpenTelemetry trace discovery and Monte Carlo resilience simulation against live container-kill experiments on the OpenTelemetry Demo.

Disclosure: I maintain MB3R Stack and am the author of the related research.

## Checklist

* [x] I added or changed one resource per pull request when possible.
* [x] The resource is in the most relevant section.
* [x] The description is short, factual, and neutral.
* [x] The link is canonical, public, and works.
* [ ] I ran `make lint` locally when possible.