### PR TITLE
Add Weckr under LLM & AI Observability > Cost & Usage Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ As LLMs and AI agents become core to modern applications, observability for thes
 - [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
 - [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - CLI that diffs an AI agent's behavior between two runs: dropped or added tool calls, changed arguments and outputs, cost and latency. Imports OTLP GenAI span exports, Langfuse and LangSmith dumps. npx-installable, MIT.
 - [grafana-llmops-forge](https://github.com/alebgl77/grafana-llmops-forge) - CLI that generates AI/LLM observability dashboards from an existing Grafana, covering FinOps by provider, agents/RAG, and EU AI Act governance. Zero-dependency.
+- [Weckr](https://github.com/Ghiles3232/weckr-sdks) - Cost and margin attribution per end customer rather than per session. SDK wrappers for OpenAI, Anthropic, Gemini and Kimi tag each call with a user id, feature and plan; cost is recomputed server-side from token counts and compared against that user's plan price, and per-plan caps block or downgrade a call before the provider bills for it. Prompts and responses are never transmitted. MIT SDKs (TypeScript, Python) with a hosted backend.
 
 ## 11. GPU Observability
 


### PR DESCRIPTION
Adds one entry to `### Cost & Usage Tracking`.

**Disclosure: I built Weckr.** Happy for it to be rejected or reworded.

### What it adds that the section does not already have

The existing entries answer "what did this run cost", mostly for coding agents, and mostly from local session files. Weckr answers a different question: which paying customer of your product is unprofitable. The SDK tags each LLM call with a user id, feature and plan at request time, so cost is attributable to an end customer and comparable against what that customer pays. No entry in the section currently does per-customer attribution.

It also enforces rather than only reports: per-plan spending caps block or downgrade a call before the provider bills for it.

### On the open source guideline

The guidelines ask for open source tools, so I want to be upfront rather than have you find it later. The SDKs are MIT and the link goes to that repo. The backend is a hosted service and is not open source.

I have followed the SourceryKit precedent already in this list, which is described as "Python SDK (source-available) with a hosted verification backend" and links to its SDK repo. My entry states "MIT SDKs (TypeScript, Python) with a hosted backend" for the same reason. If you would rather keep this section to fully open source tools, that is a fair call and I will close this without argument.

### Evaluability

The guidelines exclude "very early projects without enough information for readers to evaluate them", which is the fair objection here, so: it launched in May 2026 and has no paying users yet. What a reader can check today without signing up:

- Full docs for both SDKs: https://useweckr.com/docs and https://useweckr.com/docs/python
- The whole dashboard on seeded data, no signup: https://useweckr.com/demo
- The pricing table the backend bills from, published live with a per-provider verification date: https://useweckr.com/pricing.json
- SDK source and MIT license: https://github.com/Ghiles3232/weckr-sdks

### Checks

- Link returns 200, HTTPS, canonical repo URL, no tracking parameters.
- One resource, one PR, placed in the most relevant section, style matched to neighbouring entries.
- `awesome-lint` reports no content errors from this change. The only failures on my fork are repository-metadata ones that also occur on a clean checkout of master (missing `awesome` topics on the fork, and the known "valid git repository" false positive on any non-default branch).