### PR TITLE
Add Maple to Application Performance Monitoring Solutions (APM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Just provide your read-only credentials and start getting insights in minutes.
 - [rrweb](https://github.com/rrweb-io/rrweb) - Open-source session replay library that records the DOM and user interactions as a typed JSON event stream and replays them. Powers the session replay features of Sentry, PostHog, Amplitude, and Highlight.
 - [App Health](https://github.com/sass-maker/app-health) - Privacy-first endpoint health for Node, Go, and OpenTelemetry services; projects only method, normalized route, status, duration, timestamp, and optional release into aggregate views.
 - [Muscula](https://muscula.com/) - Error tracking, centralized logging, uptime monitoring, and debugging platform with AI agent integration via Model Context Protocol (MCP) and CLI for modern applications and websites.
+- [Maple](https://maple.dev/) - OpenTelemetry-native observability platform for traces, logs, and metrics, backed by ClickHouse, with dashboards, alerting, error tracking, service maps, and an MCP server. Source-available under FSL-1.1-ALv2, and runs as a single local binary with an embedded ClickHouse.
 
 
 ## 13. Service Mesh


### PR DESCRIPTION
Adds Maple to **12. Application Performance Monitoring Solutions (APM)**.

```markdown
- [Maple](https://maple.dev/) - OpenTelemetry-native observability platform for traces, logs, and metrics, backed by ClickHouse, with dashboards, alerting, error tracking, service maps, and an MCP server. Source-available under FSL-1.1-ALv2, and runs as a single local binary with an embedded ClickHouse.
```

Maple ingests OTLP from any OpenTelemetry SDK or the OTel Collector and stores telemetry in ClickHouse. I picked section 12 because it is where full-signal application observability platforms live (Last9, SigNoz, Middleware, TraceKit, Sentry), rather than a single-signal tool. Section 3/8 entries are collectors and visualisation components, and section 10 is LLM/agent-specific.

Things a reviewer may want to check:

- Docs: https://maple.dev/docs/
- Source: https://github.com/MapleTechLabs/maple — FSL-1.1-ALv2, source-available, each release converting to Apache-2.0 two years after publication.
- Single-binary local mode (OTLP ingest + embedded ClickHouse + dashboard, no account): https://maple.dev/docs/local-mode/
- MCP server: https://maple.dev/features/ai-mcp-integration/
- Pricing (usage-based, no per-seat or per-host fee): https://maple.dev/pricing/

Disclosure: I work on Maple.