### PR TITLE
Add Merlonix to Uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ In addition, collectors can have other responsibilities. For example, some expos
 - [Hyperping](https://hyperping.com) - Uptime, API, cron, and server monitoring from 18 locations, with on-call scheduling, escalation policies, and hosted status pages.
 - [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini). Free REST API at /api/v1/statuses, email/webhook alerts, 30-day uptime history.
 - [sunwatch](https://sunwatch.sunfamily.xyz) - Crypto-paid uptime monitoring for side projects. 3 free monitors; extras are $1/monitor/month via USDC on Base. Webhook alerts on down/up state changes. Open source.
+- [Merlonix](https://merlonix.com) - Uptime, SSL certificate, and DNS monitoring with white-label hosted status pages and a built-in MCP server for AI-agent access. Free plan includes 3 monitors, no credit card.
 
 ## 9. Processing and Analyze and Act
 


### PR DESCRIPTION
Adds **Merlonix** to the **### Uptime** section — it fits alongside the existing hosted uptime/SSL/DNS tools with status pages (Oh Dear, FlareWarden, Hyperping, Freshping).

**Merlonix** — hosted uptime, SSL certificate, and DNS monitoring with white-label status pages and a built-in MCP server for AI-agent access. Free plan includes 3 monitors, no credit card. https://merlonix.com

Per CONTRIBUTING: one resource, placed in the most relevant section, factual neutral description in the same `- [Name](url) - Description.` style as its neighbors, canonical HTTPS URL with no tracking params, and not already present in the list.